### PR TITLE
Removing schema version from template hub

### DIFF
--- a/hub-config/model-metadata-schema.json
+++ b/hub-config/model-metadata-schema.json
@@ -4,10 +4,6 @@
     "description": "This is the schema for model metadata files, please refer to https://github.com/covid19-forecast-hub-europe/covid19-forecast-hub-europe/wiki/Metadata for more information.",
     "type": "object",
     "properties": {
-        "schema_version": {
-            "type": "string",
-            "format": "uri"
-        },
         "team_name": {
             "description": "The name of the team submitting the model",
             "type": "string"
@@ -119,7 +115,6 @@
     },
     "additionalProperties": true,
     "required": [
-        "schema_version",
         "team_name",
         "team_abbr",
         "model_name",


### PR DESCRIPTION
Schema versions are not needed for the model metadata of a hub.